### PR TITLE
added forward receipt parsed by account controller

### DIFF
--- a/lib/receipt.js
+++ b/lib/receipt.js
@@ -6,6 +6,7 @@ export const Type = {
   LEAVE: 1,
   BET: 2,
   MESSAGE: 41,
+  FORWARD: 51,
   // SESSION RECEIPTS
   CREATE_CONF: 10,
   RESET_CONF: 11,
@@ -81,6 +82,26 @@ export default class Receipt {
     return new Signer(args, [payload], Type.LEAVE);
   }
 
+  forward(...args) {
+    const [nonce, destinationAddr, data] = args;
+    const dataHex = data.replace('0x', '');
+    // 1b space for v
+    // 7b targetAddr
+    // 4b nonce
+    // 20b destinationAddr
+    const dataBuf = Buffer.alloc(dataHex.length / 2, dataHex, 'hex');
+    const payload = Buffer.alloc(32);
+    // <1 bytes 0x00 space for v>
+    payload.writeInt8(0, 0);
+    // <7 bytes targetAddr>
+    payload.write(this.targetAddr.replace('0x', '').substring(26, 40), 1, 'hex');
+    // <4 bytes nonce>
+    payload.writeUInt32BE(nonce, 8);
+    // <20 bytes destinationAddr>
+    payload.write(destinationAddr.replace('0x', ''), 12, 'hex');
+    return new Signer(args, [payload, dataBuf], Type.FORWARD);
+  }
+
   message(...args) {
     let [msg, created] = args;
     const msgLength = Buffer.byteLength(msg, 'utf8');
@@ -110,7 +131,7 @@ export default class Receipt {
     payload.writeInt8(0, 0);
     // <20 bytes tableAddr>
     payload.write(this.targetAddr.replace('0x', ''), 8, 'hex');
-    // <4 bytes handId>
+    // <4 bytes message length>
     payload.writeUInt32BE(msgLength, 28);
     // <xx bytes message>
     payload.write(msg, 32, 'utf8');
@@ -202,6 +223,12 @@ export default class Receipt {
         rv.newSignerAddr = `0x${bufs.parts[2].slice(12, 32).toString('hex')}`;
         break;
       }
+      case Type.FORWARD: {
+        rv.nonce = bufs.parts[2].readUInt32BE(8);
+        rv.destinationAddr = `0x${bufs.parts[2].slice(12, 32).toString('hex')}`;
+        rv.data = `0x${bufs.parts[3].toString('hex')}`;
+        break;
+      }
       case Type.MESSAGE: {
         rv.created = parseInt(bufs.parts[2].slice(1, 8).toString('hex'), 16);
         rv.tableAddr = `0x${bufs.parts[2].slice(8, 28).toString('hex')}`;
@@ -254,6 +281,16 @@ export default class Receipt {
         hash = ethUtil.sha3(first);
         first.writeInt8(v, 0);
         partBufs.push(first);
+        break;
+      }
+      case Type.FORWARD: {
+        const dataLength = Buffer.byteLength(parts[4], 'base64');
+        const data = Buffer.alloc(dataLength);
+        data.write(parts[4], 'base64');
+        hash = ethUtil.sha3(Buffer.concat([first, data]));
+        first.writeInt8(v, 0);
+        partBufs.push(first);
+        partBufs.push(data);
         break;
       }
       case Type.MESSAGE: {

--- a/lib/receipt.spec.js
+++ b/lib/receipt.spec.js
@@ -60,6 +60,28 @@ describe('receipt + signer ', () => {
     done();
   });
 
+  it('should allow to sign and parse forward receipt.', (done) => {
+    const forwardReceipt = 'M4YP.ssWLFaCbDjXhPdVDkKrYDiAo16+TtONErnPI6VIGvr8=.UcgndJYfxVAX4fEsfd+yvTrjmybGWPJalDgR/G3lDfQ=.HN3u/wARIjMAAAAOgujGz0LI0f+VlLF6P1DpShLMhg8=.ESIzRA==';
+    const nonce = 14;
+    const controllerAddr = '0x00112233445566778899aabbccddeeff00112233';
+    const data = '0x11223344';
+    const msg = new Receipt(controllerAddr).forward(nonce, ADDR, data);
+    // test signing
+    expect(msg.sign(PRIV)).to.eql(forwardReceipt);
+    // test parse
+    // <1b nonce><7b target><4b nonce><20b destinationAddr>
+    const payload = '0x1cddeeff001122330000000e82e8c6cf42c8d1ff9594b17a3f50e94a12cc860f';
+    expect(Receipt.parseToParams(forwardReceipt)[2]).to.eql(payload);
+    expect(Receipt.parse(forwardReceipt)).to.eql({
+      nonce,
+      destinationAddr: ADDR,
+      data,
+      signer: ADDR,
+      type: Type.FORWARD,
+    });
+    done();
+  });
+
   it('should allow to sign and parse message receipt.', (done) => {
     const messageReceipt = 'KYYP.3fV+4qaDrIMB+GjyfIQJujsgNxhGjuuaivICqJr9H1c=.B6UynSr11/bwtHL2tosHNB/Q4/DBP9tKXk1H80TCQS0=.HAABW48YSGiC6MbPQsjR/5WUsXo/UOlKEsyGDwAAAAc=.bWVzc2FnZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
     const created = 1492754385000;


### PR DESCRIPTION
this receipt type represents actions that users want to send as transactions through the proxy contract. The basic parameters are:
- destinationAddr: the contract to send the tx to
- data: byteArray holding the transaction payload, usually <4b func sig><params>
- nonce + targetAddr: prevent replay attack 

this shall replace the code at https://github.com/acebusters/ab-web/blob/develop/app/containers/AccountProvider/sagas.js#L269-L284